### PR TITLE
[Context] add support for context and make minor change to component load api

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "graphql": "^0.4.14",
     "graphql-relay": "^0.3.6",
     "immutable": "^3.7.4",
+    "invariant": "^2.2.0",
     "js-babel": "^6.0.0",
     "js-babel-ui": "^6.0.0",
     "js-bdd": "^2.0.0",

--- a/src/components/Main/Component.jsx
+++ b/src/components/Main/Component.jsx
@@ -1,13 +1,13 @@
-import R from 'ramda';
-import React from 'react';
-import Radium from 'radium';
 import Immutable from 'immutable';
+import R from 'ramda';
+import Radium from 'radium';
+import React from 'react';
 import { delay } from 'js-util';
-import { css, PropTypes } from '../util';
-import CropMarks from '../shared/CropMarks';
+
 import api from '../../shared/api-internal';
-
-
+import ContextWrapper from './ContextWrapper';
+import CropMarks from '../shared/CropMarks';
+import { css, PropTypes } from '../util';
 
 /**
  * Loads and displays a component.
@@ -69,6 +69,9 @@ class Component extends React.Component {
         });
       }
       element = React.createElement(type, props, children);
+
+      const childContextTypes = current.get('componentChildContextTypes');
+      if (childContextTypes) ContextWrapper.childContextTypes = childContextTypes;
     }
 
     const cropMarksSize = current.get('cropMarks')
@@ -83,7 +86,11 @@ class Component extends React.Component {
         display={ width === '100%' ? 'block' : 'inline-block' }
         width={ width }
         height={ height }>
-        <div style={ styles.base }>{ element }</div>
+        <div style={ styles.base }>
+          <ContextWrapper context={current.get('componentContext')}>
+            { element }
+          </ContextWrapper>
+        </div>
       </CropMarks>
     );
   }

--- a/src/components/Main/ContextWrapper.jsx
+++ b/src/components/Main/ContextWrapper.jsx
@@ -1,0 +1,16 @@
+import { Component } from 'react';
+
+import { PropTypes } from '../util';
+
+const { object, node } = PropTypes;
+
+class ContextWrapper extends Component {
+  static propTypes = {
+    context: object,
+    children: node.isRequired,
+  }
+  getChildContext = () => this.props.context
+  render() { return this.props.children || null; }
+}
+
+export default ContextWrapper;

--- a/src/shared/api-internal.js
+++ b/src/shared/api-internal.js
@@ -1,10 +1,12 @@
-import R from 'ramda';
-import Promise from 'bluebird';
-import React from 'react';
-import Immutable from 'immutable';
+import invariant from 'invariant';
 import localStorage from 'js-util/lib/local-storage';
-import bdd from './bdd';
+import Immutable from 'immutable';
+import Promise from 'bluebird';
+import R from 'ramda';
+import React from 'react';
+
 import apiConsole from './api-console';
+import bdd from './bdd';
 import GettingStarted from '../components/docs/GettingStarted';
 
 const LOG_LIST = Symbol('log-list');
@@ -178,29 +180,19 @@ class Api {
    *                    with a component element).
    *
    */
-  loadComponent(component, props, children) {
-    // Setup initial conditions.
-    if (!component) { throw new Error('Componnet not specified.'); }
+  loadComponent(component) {
+    invariant(component, 'Component not specified in this.component().');
 
-    // If a created <element> was passed de-construct
-    // it into it's component parts.
-    let type;
+    // If a React element was passed pull out its type.
+    const updates = {};
     if (React.isValidElement(component)) {
-      props = R.clone(component.props);
-      children = props.children;
-      delete props.children;
-      type = component.type;
+      updates.componentType = component.type;
     } else {
-      type = component;
+      updates.componentType = component;
     }
 
     // Store on the current state.
-    this.setCurrent({
-      componentType: type,
-      componentProps: props,
-      componentChildren: children,
-      showLog: false,
-    });
+    this.setCurrent(updates);
 
     // Finish up.
     this.loadInvokeCount += 1;

--- a/src/specs/ComponentHost.spec.jsx
+++ b/src/specs/ComponentHost.spec.jsx
@@ -1,12 +1,17 @@
-import React from 'react';
-import Radium from 'radium';
-import { lorem, css, PropTypes } from './util';
 import Foo from 'react-atoms/components/Foo';
+import R from 'ramda';
+import Radium from 'radium';
+import React from 'react';
+import { Value } from 'react-object';
+
 import api from '../shared/api-internal';
-
-
+import { lorem, css, PropTypes } from './util';
 
 class MyFoo extends React.Component {
+  static contextTypes = {
+    store: PropTypes.object,
+  }
+
   styles() {
     return css({
       base: {
@@ -21,6 +26,7 @@ class MyFoo extends React.Component {
     return (
       <div style={ styles.base }>
         <div>foo:{ this.props.foo }</div>
+        <div>Context:<Value value={this.context} /></div>
         { this.props.children }
       </div>
     );
@@ -62,6 +68,22 @@ describe('Component Host', function() {
     });
   });
 
+  section('context', () => {
+    it('reload with context', () => {
+      this.load({
+        component: MyFoo,
+        contextTypes: {
+          store: PropTypes.object.isRequired
+        }
+      });
+    });
+    it('Redux Store Context', () => {
+      this.context({ store: ({ getState: () => ({ contextWorks: true }) }) })
+    });
+    it('add dispatch', () => {
+      this.context({ store: ({ dispatch: () => v => console.info(`dispatched ${v && v.type}`) }) })
+    });
+  });
 
   section('children', () => {
     it('date', () => {

--- a/test/shared/ThisContext-load.test.js
+++ b/test/shared/ThisContext-load.test.js
@@ -1,9 +1,9 @@
-import { expect } from 'chai';
 import React from 'react';
-import ThisContext from '../../src/shared/ThisContext';
-import bdd from '../../src/shared/bdd';
-import api from '../../src/shared/api-internal';
+import { expect } from 'chai';
 
+import api from '../../src/shared/api-internal';
+import bdd from '../../src/shared/bdd';
+import ThisContext from '../../src/shared/ThisContext';
 
 class Foo extends React.Component {
   render() {
@@ -27,14 +27,16 @@ describe('ThisContext: load', () => {
 
 
   it('returns an instance of the [self] context', () => {
-    expect(self.load()).to.equal(self);
-    expect(self.load(Foo)).to.equal(self);
+    expect(self.component(Foo)).to.equal(self);
   });
 
 
   describe('Storing Type, Props and Children on the [current] state', () => {
     it('from individual args', () => {
-      self.load(Foo, { text: 'hello' }, 'child');
+      self
+        .props({ text: 'hello' })
+        .children('child')
+        .component(Foo);
       expect(api.current.get('componentType')).to.equal(Foo);
       expect(api.current.get('componentProps')).to.eql({ text: 'hello' });
       expect(api.current.get('componentChildren')).to.equal('child');
@@ -42,7 +44,7 @@ describe('ThisContext: load', () => {
 
     it('from element', () => {
       let foo = React.createElement(Foo, { text: 'hello' }, 'child');
-      self.load(foo);
+      self.component(foo);
       expect(api.current.get('componentType')).to.equal(Foo);
       expect(api.current.get('componentProps')).to.eql({ text: 'hello' });
       expect(api.current.get('componentChildren')).to.equal('child');

--- a/test/shared/ThisContext-props.test.js
+++ b/test/shared/ThisContext-props.test.js
@@ -1,17 +1,18 @@
 import R from 'ramda';
 import { expect } from 'chai';
-import ThisContext from '../../src/shared/ThisContext';
-import bdd from '../../src/shared/bdd';
-import api from '../../src/shared/api-internal';
+import { PropTypes } from 'react-schema';
 
+import api from '../../src/shared/api-internal';
+import bdd from '../../src/shared/bdd';
 
 describe('ThisContext', () => {
-  let suite, context;
-  afterEach(() => { bdd.reset(); })
+  let suite;
+  let context;
+  afterEach(() => { bdd.reset(); });
   beforeEach(() => {
     bdd.register();
-    suite = describe(`My Suite`, () => { });
-    api.setCurrent({ suite: suite });
+    suite = describe(`My Suite`, () => {});
+    api.setCurrent({ suite });
     context = suite.meta.thisContext;
   });
 
@@ -47,14 +48,14 @@ describe('ThisContext', () => {
     });
 
     it('throws on invalid values', () => {
-      expect(() => { context.cropMarks(123) }).to.throw();
-      expect(() => { context.cropMarks.size(true) }).to.throw();
-      expect(() => { context.cropMarks.offset(true) }).to.throw();
+      expect(() => { context.cropMarks(123); }).to.throw();
+      expect(() => { context.cropMarks.size(true); }).to.throw();
+      expect(() => { context.cropMarks.offset(true); }).to.throw();
     });
   });
 
 
-  describe('size (width/height)', function() {
+  describe('size (width/height)', function() { // eslint-disable-line prefer-arrow-callback
     it('has not width/height by default ("auto")', () => {
       expect(context.width()).to.equal('auto');
       expect(context.height()).to.equal('auto');
@@ -63,41 +64,41 @@ describe('ThisContext', () => {
     it('stores width/height (number)', () => {
       context
         .width(250)
-        .height(120)
+        .height(120);
       expect(context.width()).to.equal(250);
       expect(context.height()).to.equal(120);
     });
 
     it('resets with `null`', () => {
-      context.width(250).height(120)
-      context.width(null).height(null)
+      context.width(250).height(120);
+      context.width(null).height(null);
       expect(context.width()).to.equal('auto');
       expect(context.height()).to.equal('auto');
     });
 
     it('width throws if a number of string is not passed', () => {
-      let fn = () => {
+      const fn = () => {
         context
           .width(250)
           .width('100%')
-          .width({ foo: 123 })
+          .width({ foo: 123 });
       };
       expect(fn).to.throw();
     });
 
     it('height throws if a number of string is not passed', () => {
-      let fn = () => {
+      const fn = () => {
         context
           .height(250)
           .height('100%')
-          .height({ foo: 123 })
+          .height({ foo: 123 });
       };
       expect(fn).to.throw();
     });
   });
 
 
-  describe('margin', function() {
+  describe('margin', function () { // eslint-disable-line prefer-arrow-callback
     it('it has a default value', () => {
       expect(R.is(Number, context.margin())).to.equal(true);
     });
@@ -107,12 +108,12 @@ describe('ThisContext', () => {
     });
 
     it('throws if a number of string is not passed', () => {
-      expect(() => { context.margin({}) }).to.throw();
+      expect(() => { context.margin({}); }).to.throw();
     });
   });
 
 
-  describe('align', function() {
+  describe('align', function () { // eslint-disable-line prefer-arrow-callback
     it('has a default value', () => {
       expect(context.align()).to.equal('center top');
     });
@@ -131,7 +132,7 @@ describe('ThisContext', () => {
   });
 
 
-  describe('header', function() {
+  describe('header', function () {
     it('is undefined by default', () => {
       expect(context.header()).to.equal(undefined);
     });
@@ -158,19 +159,19 @@ describe('ThisContext', () => {
     });
 
     it('throws if not boolean', () => {
-      expect(() => { context.hr('hello') }).to.throw();
+      expect(() => { context.hr('hello'); }).to.throw();
     });
   });
 
 
-  describe('backdrop', function() {
+  describe('backdrop', function () { // eslint-disable-line prefer-arrow-callback
     it('has default value', () => {
       expect(context.backdrop()).to.equal(0);
     });
 
     it('throws if not number or string', () => {
       context.backdrop(0).backdrop('red');
-      let fn = () => { context.backdrop({}); };
+      const fn = () => { context.backdrop({}); };
       expect(fn).to.throw();
     });
   });
@@ -206,7 +207,12 @@ describe('ThisContext', () => {
     });
 
     it('throws if not an object', () => {
-      expect(() => context.context(123)).to.throw();
+      expect(() => context
+        .childContextTypes({
+          someKey: PropTypes.object,
+        })
+        .context(123)
+      ).to.throw();
     });
 
     it('stores the given object', () => {
@@ -215,12 +221,36 @@ describe('ThisContext', () => {
         dispatch: () => true,
         subscribe: () => true,
       };
-      expect(context.context(myContext).context()).to.equal(myContext);
+      expect(context
+        .childContextTypes({
+          getState: PropTypes.func,
+          dispatch: PropTypes.func,
+          subscribe: PropTypes.func,
+        })
+        .context(myContext)
+        .context()
+      ).to.deep.equal(myContext);
     });
 
     it('is chainable', () => {
-      const result = context.context({ foo:123 });
+      const result = context
+        .childContextTypes({ foo: PropTypes.object })
+        .context({ foo: 123 })
+        ;
       expect(result).to.equal(context);
+    });
+
+    it('throws when trying to set a context key that was not defined in context types', () => {
+      expect(() => context
+        .childContextTypes({ defined: PropTypes.object })
+        .context({ not_defined: 123 })
+      ).to.throw(/not specified/);
+    });
+
+    it('throws when trying to set context before context types', () => {
+      expect(() => context
+        .context({ not_defined: 123 })
+      ).to.throw(/contextTypes are not set/);
     });
   });
 });


### PR DESCRIPTION
Some things to discuss before this is merged:

### loadComponent API
I have extended the `loadComponent` syntax to allow `this.load` in the form `this.load({ component, props, contextTypes, children})`. Example usage:
```js
this.load({
  component: MyFoo,
  contextTypes: {
    store: PropTypes.object.isRequired
  },
  props: {
    foo: 1234,
  },
});
``` 
I feel that this is a valuable addition to the API because it is more extensible than the previous APIs. If we are to introduce `contextTypes` and `context`, users of the library are more prone to make mistakes as they have to remember the exact position of context and contextTypes in the function parameters, whereas with an object, it is more explicit and obvious. :+1:

- :+1: more explicit
- :+1: easier for new users to use context API
- :+1: less likely to break ui-harness specs when changing either ui-harness api or as a consumer changing components
- :-1: more complexity in ui-harness source (but not much)

### Use of updeep for context object merging
This should really be broken out into a seperate PR. Nevertheless, I have used updeep for context updating. It is basically a deep "immutable" object merge, which I have used to great success at Holis for the last half a year or so. You can compare the `props()` and `context()` methods in api-internal to see what it does, they have the same effect.

- :+1: It allows the caller to update the values currently stored at a certain path. e.g. given `a = {b: {c: 1}}`, `u({b: {c: v => v + 1}}, a)` would produce `{b: {c: 2}}`.
- :+1: semi-immutable (immutable concepts without actually enforcing them)
- :-1: quirks when trying to set an object as a function, as it actually passes the current value at that key to the function (see ComponentHost.spec.jsx line 84)
- :-1: not sure how many people would use it?

---

Otherwise, this works much as I thought it would. When loading a component, you **must** declare its childContextTypes using `this.load({contextTypes: {}})`, and then you can change its context just like you change its props.

---

To come in future PRs with this as the foundation: 

- Redux context wrapper
- Declarative API

Also closes #21 