### PR TITLE
Webpack: css-loader.

### DIFF
--- a/.uiharness.yml
+++ b/.uiharness.yml
@@ -15,3 +15,5 @@ build:
   vendor:
     - react
     - react-dom
+
+cssModules: .module.css

--- a/README.md
+++ b/README.md
@@ -121,19 +121,19 @@ proxy:
 By default the UIHarness supports the webpack [css-loader] for `*.css` files.  If however you wish to use [css-modules] simply declare the file extension of your modules in the `.uiharness.yml` with a regular-expression like this:
 
 ```yaml
-css-modules: .css
+cssModules: .css
 ```
 
 If you wish to retain the default [css-loader] behavior but still want to use [css-modules], you can specify [css-modules] to only work on certain extensions:
 
 ```yaml
-css-modules: .module.css
+cssModules: .module.css
 ```
 
 And if you wish to use several different extensions for [css-modules] you can specify a list:
 
 ```yaml
-css-modules:
+cssModules:
   - .css
   - .module.css
 ```

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ http://uiharness.com
 ![ScreenShot](https://cloud.githubusercontent.com/assets/185555/10448258/0471dece-71e8-11e5-983a-028dd7df7a1a.png)
 
 
+
+
 ## Quick Start (1-minute)
 With the UIHarness you can go from an empty NPM module, to cleanly building isolated React components using best-practices in well under a minute.
 
@@ -113,6 +115,29 @@ graphqlSchema: './data/schema.js'
 proxy:
   /graphql: http://localhost:8080
 ```
+
+
+### CSS
+By default the UIHarness supports the webpack [css-loader](https://github.com/webpack/css-loader) for `*.css` files.  If however you wish to use [css-modules](https://github.com/css-modules/css-modules) simply declare the file extension of your modules in the `.uiharness.yml` with a regular-expression like this:
+
+```yaml
+css-modules: /\.css$/
+```
+
+If you wish to retain the default [css-loader](https://github.com/webpack/css-loader) behavior and [css-modules](https://github.com/css-modules/css-modules), don't use the `*.css` extension, but rather use something like:
+
+```yaml
+css-modules: /\.module.css$/
+```
+
+And if you wish to use several different extensions for [css-modules](https://github.com/css-modules/css-modules) you can specify a list:
+```yaml
+css-modules:
+  - /\.css$/
+  - /\.module.css$/
+```
+
+
 
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ A path to the [GraphQL](https://facebook.github.io/graphql/) `schema.js` file. I
 
 
 ```yml
-entry: ./src/specs
+entry: ./src/specs  # Path, comma-seperated paths, or array of paths.
 port: 3030
 graphqlSchema: './data/schema.js'
 proxy:

--- a/README.md
+++ b/README.md
@@ -124,17 +124,17 @@ By default the UIHarness supports the webpack [css-loader](https://github.com/we
 css-modules: /\.css$/
 ```
 
-If you wish to retain the default [css-loader](https://github.com/webpack/css-loader) behavior and [css-modules](https://github.com/css-modules/css-modules), don't use the `*.css` extension, but rather use something like:
+If you wish to retain the default [css-loader](https://github.com/webpack/css-loader) behavior but still want to use css-modules, you can specify [css-modules](https://github.com/css-modules/css-modules) to only work on certain extensions:
 
 ```yaml
-css-modules: /\.module.css$/
+css-modules: /\.module\.css$/
 ```
 
 And if you wish to use several different extensions for [css-modules](https://github.com/css-modules/css-modules) you can specify a list:
 ```yaml
 css-modules:
   - /\.css$/
-  - /\.module.css$/
+  - /\.module\.css$/
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -121,21 +121,21 @@ proxy:
 By default the UIHarness supports the webpack [css-loader] for `*.css` files.  If however you wish to use [css-modules] simply declare the file extension of your modules in the `.uiharness.yml` with a regular-expression like this:
 
 ```yaml
-css-modules: /\.css$/
+css-modules: .css
 ```
 
 If you wish to retain the default [css-loader] behavior but still want to use [css-modules], you can specify [css-modules] to only work on certain extensions:
 
 ```yaml
-css-modules: /\.module\.css$/
+css-modules: .module.css
 ```
 
 And if you wish to use several different extensions for [css-modules] you can specify a list:
 
 ```yaml
 css-modules:
-  - /\.css$/
-  - /\.module\.css$/
+  - .css
+  - .module.css
 ```
 
 [css-loader]: https://github.com/webpack/css-loader

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui-harness",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "Isolate, test and document modular UI with React.",
   "main": "./lib/server",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "chalk": "^1.1.1",
     "color": "^0.11.1",
     "compression": "^1.5.2",
+    "css-loader": "^0.23.1",
     "express": "^4.13.0",
     "express-graphql": "^0.4.5",
     "file-loader": "^0.8.4",
@@ -49,6 +50,7 @@
     "react-schema": "^1.1.0",
     "semver": "^5.1.0",
     "shelljs": "^0.6.0",
+    "style-loader": "^0.13.0",
     "url-loader": "^0.5.7",
     "webpack": "^1.12.11",
     "webpack-dev-server": "^1.14.1"

--- a/src/server/start.js
+++ b/src/server/start.js
@@ -52,6 +52,7 @@ export default (options = {}) => new Promise((resolve, reject) => {
     const port = options.port || YAML_CONFIG.port || 3030;
     const proxy = options.proxy || YAML_CONFIG.proxy;
     const graphqlSchema = options.graphqlSchema || YAML_CONFIG.graphqlSchema;
+    const cssModules = options.cssModules || YAML_CONFIG.cssModules;
 
     // Ensure required values exist.
     if (R.isNil(entry) || R.isEmpty(entry)) { throw new Error(`Entry path(s) must be specified.`); }
@@ -81,6 +82,7 @@ export default (options = {}) => new Promise((resolve, reject) => {
       isRelayEnabled,
       entry: specs,
       outputFile: 'specs.js',
+      cssModules,
     });
 
     // Create the development server.

--- a/src/server/webpack-config.js
+++ b/src/server/webpack-config.js
@@ -61,6 +61,9 @@ const babelLoader = (extension, isRelayEnabled) => {
  *                                Pass empty-array for no vendor modules
  *                                otherwise the default set of vendors is included.
  *
+ *            -- cssModules:      An array of regular expressions.
+ *                                Default: undefined.
+ *
  * @return {Object} compiler.
  */
 export default (options = {}) => {
@@ -83,7 +86,6 @@ export default (options = {}) => {
       loaders: [
         babelLoader(/\.js$/, isRelayEnabled),
         babelLoader(/\.jsx$/, isRelayEnabled),
-        { test: /\.css$/, loader: 'style!css' },
         { test: /\.json$/, loader: 'json' },
         { test: /\.(png|svg)$/, loader: 'url' },
       ],
@@ -108,6 +110,27 @@ export default (options = {}) => {
       new webpack.optimize.CommonsChunkPlugin({ name: 'vendor', path: '/', filename: 'vendor.js' }),
     ],
   };
+
+  // Configure CSS loaders
+  const { loaders } = config.module;
+  const { cssModules } = options;
+  const simpleCssLoader = { test: /\.css$/, loader: 'style!css' };
+  if (cssModules) {
+    let simpleLoaderAdded = false;
+    cssModules.forEach(test => {
+      loaders.push({ test, loader: 'style!css?module' });
+      if (test.toString() === simpleCssLoader.test.toString()) {
+        simpleLoaderAdded = true;
+      }
+    });
+    // Add the simple CSS loader if the extension was not included for css-module's.
+    if (!simpleLoaderAdded) {
+      loaders.push(simpleCssLoader);
+    }
+  } else {
+    // Add simple CSS loader (default).
+    loaders.push(simpleCssLoader);
+  }
 
   // Configure optional plugins.
   //    See - https://webpack.github.io/docs/list-of-plugins.html

--- a/src/server/webpack-config.js
+++ b/src/server/webpack-config.js
@@ -118,7 +118,14 @@ export default (options = {}) => {
   if (cssModules) {
     let simpleLoaderAdded = false;
     cssModules.forEach(test => {
-      loaders.push({ test, loader: 'style!css?module' });
+      loaders.push({
+        test,
+        loader: 'style!css?modules',
+
+        // Loader syntax below from:
+        //    https://github.com/css-modules/webpack-demo
+        // loader: 'style!css-loader?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]',
+      });
       if (test.toString() === simpleCssLoader.test.toString()) {
         simpleLoaderAdded = true;
       }

--- a/src/server/webpack-config.js
+++ b/src/server/webpack-config.js
@@ -83,6 +83,7 @@ export default (options = {}) => {
       loaders: [
         babelLoader(/\.js$/, isRelayEnabled),
         babelLoader(/\.jsx$/, isRelayEnabled),
+        { test: /\.css$/, loader: 'style-loader!css-loader' },
         { test: /\.json$/, loader: 'json-loader' },
         { test: /\.(png|svg)$/, loader: 'url-loader' },
       ],

--- a/src/server/webpack-config.js
+++ b/src/server/webpack-config.js
@@ -83,9 +83,9 @@ export default (options = {}) => {
       loaders: [
         babelLoader(/\.js$/, isRelayEnabled),
         babelLoader(/\.jsx$/, isRelayEnabled),
-        { test: /\.css$/, loader: 'style-loader!css-loader' },
-        { test: /\.json$/, loader: 'json-loader' },
-        { test: /\.(png|svg)$/, loader: 'url-loader' },
+        { test: /\.css$/, loader: 'style!css' },
+        { test: /\.json$/, loader: 'json' },
+        { test: /\.(png|svg)$/, loader: 'url' },
       ],
     },
     devtool: isProduction ? undefined : 'cheap-module-eval-source-map',

--- a/src/server/yaml-config.js
+++ b/src/server/yaml-config.js
@@ -63,7 +63,7 @@ export const parse = (text) => {
   if (cssModules) {
     cssModules = R.is(Array, cssModules) ? cssModules : [cssModules];
     cssModules = cssModules.map(toFileExtensionRegEx);
-    yaml.cssModules = cssModules
+    yaml.cssModules = cssModules;
   }
 
   // Finish up.

--- a/src/server/yaml-config.js
+++ b/src/server/yaml-config.js
@@ -16,6 +16,17 @@ const formatPath = (path) => {
     : path;
 };
 
+const toFileExtensionRegEx = (item) => {
+  if (!(item instanceof RegExp)) {
+    item = item.replace(/\./g, '\\.');
+    item = new RegExp(`${ item }$`);
+  }
+  return item;
+};
+
+
+
+
 
 
 /**
@@ -45,6 +56,14 @@ export const parse = (text) => {
   // Format GraphQL path.
   if (yaml.graphqlSchema) {
     yaml.graphqlSchema = formatPath(yaml.graphqlSchema);
+  }
+
+  // Format css-modules.
+  let cssModules = yaml.cssModules;
+  if (cssModules) {
+    cssModules = R.is(Array, cssModules) ? cssModules : [cssModules];
+    cssModules = cssModules.map(toFileExtensionRegEx);
+    yaml.cssModules = cssModules
   }
 
   // Finish up.

--- a/src/specs/css-loader.css
+++ b/src/specs/css-loader.css
@@ -5,3 +5,7 @@
   margin-bottom: 15px;
   padding: 15px;
 }
+
+.css-loader-sample p:last-child {
+  margin-bottom: 0;
+}

--- a/src/specs/css-loader.css
+++ b/src/specs/css-loader.css
@@ -1,5 +1,5 @@
 
-.css-sample p {
+.css-loader-sample p {
   background-color: rgba(255, 0, 0, 0.1);
   margin: 0;
   margin-bottom: 15px;

--- a/src/specs/css-loader.css
+++ b/src/specs/css-loader.css
@@ -1,0 +1,7 @@
+
+.css-sample p {
+  background-color: rgba(255, 0, 0, 0.1);
+  margin: 0;
+  margin-bottom: 15px;
+  padding: 15px;
+}

--- a/src/specs/css-loader.spec.jsx
+++ b/src/specs/css-loader.spec.jsx
@@ -9,21 +9,17 @@ if (IS_BROWSER) {
 
 
 
-class CssSample extends React.Component {
-  render() {
-    return (
-      <div className="css-sample">
-        <p>{ lorem(50) }</p>
-        <p>{ lorem(50) }</p>
-      </div>
-    );
-  }
-}
+const CssSample = () => (
+  <div className="css-loader-sample">
+    <p>{ lorem(50) }</p>
+    <p>{ lorem(50) }</p>
+  </div>
+);
 
 
 
-describe('CSS', function() {
-  this.header(`## CSS via webpack css-loader.`);
+describe('css-loader', function() {
+  this.header(`## Webpack simple CSS loader.`);
   before(() => {
     this
       .component( <CssSample/> );

--- a/src/specs/css-loader.spec.jsx
+++ b/src/specs/css-loader.spec.jsx
@@ -13,6 +13,7 @@ const CssSample = () => (
   <div className="css-loader-sample">
     <p>{ lorem(50) }</p>
     <p>{ lorem(50) }</p>
+    <p>{ lorem(50) }</p>
   </div>
 );
 

--- a/src/specs/css-loader.spec.jsx
+++ b/src/specs/css-loader.spec.jsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import { lorem } from './util';
-import './css-loader.css';
+
+
+const IS_BROWSER = typeof(window) !== 'undefined';
+if (IS_BROWSER) {
+  require('./css-loader.css');
+}
+
 
 
 class CssSample extends React.Component {

--- a/src/specs/css-loader.spec.jsx
+++ b/src/specs/css-loader.spec.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { lorem } from './util';
+import './css-loader.css';
+
+
+class CssSample extends React.Component {
+  render() {
+    return (
+      <div className="css-sample">
+        <p>{ lorem(50) }</p>
+        <p>{ lorem(50) }</p>
+      </div>
+    );
+  }
+}
+
+
+
+describe('CSS', function() {
+  this.header(`## CSS via webpack css-loader.`);
+  before(() => {
+    this
+      .component( <CssSample/> );
+  });
+});

--- a/src/specs/css-module.module.css
+++ b/src/specs/css-module.module.css
@@ -1,0 +1,10 @@
+.css-module-sample p {
+  background-color: rgba(255, 125, 0, 0.1);
+  margin: 0;
+  margin-bottom: 15px;
+  padding: 15px;
+}
+
+.css-module-sample p:last-child {
+  margin-bottom: 0;
+}

--- a/src/specs/css-module.spec.jsx
+++ b/src/specs/css-module.spec.jsx
@@ -4,8 +4,8 @@ import { lorem } from './util';
 const IS_BROWSER = typeof(window) !== 'undefined';
 let css;
 if (IS_BROWSER) {
-  css = require('./css-module.module.css');
-  console.log("css", css);
+  // css = require('./css-module.module.css');
+  // console.log("css", css);
 }
 
 

--- a/src/specs/css-module.spec.jsx
+++ b/src/specs/css-module.spec.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { lorem } from './util';
+
+
+
+const CssSample = () => (
+  <div className="css-module-sample">
+    <p>{ lorem(50) }</p>
+    <p>{ lorem(50) }</p>
+  </div>
+);
+
+
+
+
+describe('css-module', function() {
+  this.header(`## Webpack CSS modules.`);
+  before(() => {
+    this
+      .component( <CssSample/> );
+  });
+});

--- a/src/specs/css-module.spec.jsx
+++ b/src/specs/css-module.spec.jsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import { lorem } from './util';
 
+const IS_BROWSER = typeof(window) !== 'undefined';
+let css;
+if (IS_BROWSER) {
+  css = require('./css-module.module.css');
+  console.log("css", css);
+}
+
 
 
 const CssSample = () => (

--- a/src/specs/index.js
+++ b/src/specs/index.js
@@ -1,6 +1,7 @@
 describe('ui-harness', function() {
   require('./ComponentHost.spec');
   require('./css-loader.spec');
+  require('./css-module.spec');
   require('./OutputLog.spec');
   require('./header-footer.spec');
   require('./skipped.spec');

--- a/src/specs/index.js
+++ b/src/specs/index.js
@@ -1,5 +1,6 @@
 describe('ui-harness', function() {
   require('./ComponentHost.spec');
+  require('./css-loader.spec');
   require('./OutputLog.spec');
   require('./header-footer.spec');
   require('./skipped.spec');

--- a/test/server/yaml-config.test.js
+++ b/test/server/yaml-config.test.js
@@ -30,6 +30,34 @@ describe('YAML config (.uiharness)', function() {
       const config = yamlConfig.parse(yaml);
       expect(config.entry).to.eql(['/foo/specs']);
     });
+
+    describe('css-modules', function() {
+      it('has no css-modules declaration by default', () => {
+        const yaml = `
+          entry: /foo/specs
+        `;
+        const config = yamlConfig.parse(yaml);
+        expect(config.cssModules).to.eql(undefined);
+      });
+
+      it('has an array of css-module declarations (single string)', () => {
+        expect(yamlConfig.parse('cssModules: .css').cssModules).to.eql([/\.css$/]);
+      });
+
+      it('has an array of css-module declarations (array)', () => {
+        expect(yamlConfig.parse('cssModules: [".css"]').cssModules).to.eql([/\.css$/]);
+      });
+
+      it('has an array of css-module declarations (list)', () => {
+        const yaml = `
+          cssModules:
+            - .css
+            - .module.css
+        `;
+        const config = yamlConfig.parse(yaml);
+        expect(config.cssModules).to.eql([/\.css$/, /\.module\.css$/]);
+      });
+    });
   });
 
 


### PR DESCRIPTION
See issue #51.

This PR adds the vanilla `css-loader` (along with it's dependency `style-loader`).  This does not get into adding specific pre-processors (like Stylus and Less) intentionally.  Let's have an extensible way of doing that so that we don't bloat the core module up with every conceivable loader.