### PR TITLE
[ThisContext] Make sure props are merged and not just set

### DIFF
--- a/src/shared/ThisContext.js
+++ b/src/shared/ThisContext.js
@@ -6,9 +6,8 @@ import R from 'ramda';
 import schema, { PropTypes } from 'react-schema';
 
 import api from './api-internal';
-import page from './page';
 import log from './log';
-
+import page from './page';
 
 const PROP = Symbol('Prop');
 const PROPS = {
@@ -189,8 +188,7 @@ export default class UIHContext {
     if (R.is(Object, _value)) {
       // Cumulatively add given props to the existing
       // props on the component.
-      const component = this[PROP]('componentProps');
-      const props = (component && component.props) || {};
+      const props = this[PROP]('componentProps');
       // No need to clone when using R.merge
       _value = R.merge(props, _value);
     }

--- a/test/shared/ThisContext-component.test.js
+++ b/test/shared/ThisContext-component.test.js
@@ -21,7 +21,7 @@ describe('ThisContext: load', () => {
   });
 
   beforeEach(() => {
-    api.reset({ hard:true });
+    api.reset({ hard: true });
     self = new ThisContext();
   });
 
@@ -49,5 +49,20 @@ describe('ThisContext: load', () => {
       expect(api.current.get('componentProps')).to.eql({ text: 'hello' });
       expect(api.current.get('componentChildren')).to.equal('child');
     });
+  });
+
+  it('allows props to be set after the component has loaded', () => {
+    self
+      .component(Foo)
+      .props({ a: 1 });
+    expect(api.current.get('componentProps')).to.eql({ a: 1 });
+  });
+
+  it('merges prop into current props', () => {
+    self
+      .props({ a: 1 })
+      .props({ b: 2 })
+      .component(Foo);
+    expect(api.current.get('componentProps')).to.eql({ a: 1, b: 2 });
   });
 });


### PR DESCRIPTION
So I was using the ui-harness, and I was like "Why ain't these props mergin'?", so I decided to write some tests in the source, and turns out, they weren't merging! And even worse, it was code I wrote! **This fixes that.**

Also, please help me try make the first test pass. If I remove this if statement https://github.com/philcockfield/ui-harness/blob/merge-props/src/shared/ThisContext.js#L117 it passes.

Is that check even needed? Are changes going to be called when the suite isn't loaded? Only reason I can think of is people doing async calls in `it` methods... that would be crazy