### PR TITLE
fixed test: ThisContext-component.test.js

### DIFF
--- a/test/shared/ThisContext-component.test.js
+++ b/test/shared/ThisContext-component.test.js
@@ -15,14 +15,14 @@ class Foo extends React.Component {
 
 describe('ThisContext: load', () => {
   let self;
-  before(() => {
-    bdd.reset();
-    bdd.register();
-  });
 
+  let suite;
+  afterEach(() => { bdd.reset(); });
   beforeEach(() => {
-    api.reset({ hard: true });
-    self = new ThisContext();
+    bdd.register();
+    suite = describe(`My Suite`, () => {});
+    api.setCurrent({ suite });
+    self = suite.meta.thisContext;
   });
 
 


### PR DESCRIPTION
* The context wasn't emulated correctly so the `isCurrent()` check of `UIHContext` failed.
* I borrowed the `beforeEach` and `afterEach` from 'ThisContext-props.test.js' 
* Should fix ci of #56 