### PR TITLE
Walk tree looking for react module.

### DIFF
--- a/src/server/build.js
+++ b/src/server/build.js
@@ -169,7 +169,8 @@ export default (buildConfig, options = {}) => new Promise((resolve, reject) => {
     .then(() => startBuilders())
     .then(builders => Promise.all(builders))
     .then(results => {
-      const secs = Math.round(R.reduce((prev, curr) => prev + curr.stats.buildTime.secs, 0, results));
+      const totalTime = R.reduce((prev, curr) => prev + curr.stats.buildTime.secs, 0, results);
+      const secs = Math.round(totalTime);
       const files = results.map(item => fsPath.join(outputFolder, `${ item.filename }.js`));
 
       // Log results.

--- a/src/server/build.js
+++ b/src/server/build.js
@@ -169,7 +169,7 @@ export default (buildConfig, options = {}) => new Promise((resolve, reject) => {
     .then(() => startBuilders())
     .then(builders => Promise.all(builders))
     .then(results => {
-      const secs = R.reduce((prev, curr) => prev + curr.stats.buildTime.secs, 0, results);
+      const secs = Math.round(R.reduce((prev, curr) => prev + curr.stats.buildTime.secs, 0, results));
       const files = results.map(item => fsPath.join(outputFolder, `${ item.filename }.js`));
 
       // Log results.

--- a/src/server/paths.js
+++ b/src/server/paths.js
@@ -22,10 +22,31 @@ export const rootModulePath = () => {
     ? fsPath.resolve('../../')
     : fsPath.resolve('./');
 };
-
-
-
 const ROOT_PATH = rootModulePath();
+
+
+
+/**
+ * Walks up the folder hierarchy looking for the closest module.
+ * @param {String} moduleDir: The path to the module directory
+ *                            (ie. the parent of node_modules).
+ * @param {String} moduleName: The name of the module you are looking for.
+ *
+ * @return {String}.
+ */
+export const closestModulePath = (moduleDir, moduleName) => {
+  const dir = fsPath.join(moduleDir, 'node_modules', moduleName);
+  if (fs.existsSync(dir)) {
+    return dir;
+  } else {
+    // Not found, walk up the folder-hierarhcy.
+    const parent = fsPath.resolve(moduleDir, '..');
+    if (parent !== '/') {
+      return closestModulePath(parent, moduleName); // <== RECURSION.
+    }
+  }
+  return undefined;
+};
 
 
 

--- a/src/server/paths.js
+++ b/src/server/paths.js
@@ -38,12 +38,11 @@ export const closestModulePath = (moduleDir, moduleName) => {
   const dir = fsPath.join(moduleDir, 'node_modules', moduleName);
   if (fs.existsSync(dir)) {
     return dir;
-  } else {
-    // Not found, walk up the folder-hierarhcy.
-    const parent = fsPath.resolve(moduleDir, '..');
-    if (parent !== '/') {
-      return closestModulePath(parent, moduleName); // <== RECURSION.
-    }
+  }
+  // Not found, walk up the folder-hierarhcy.
+  const parent = fsPath.resolve(moduleDir, '..');
+  if (parent !== '/') {
+    return closestModulePath(parent, moduleName); // <== RECURSION.
   }
   return undefined;
 };

--- a/src/server/webpack-config.js
+++ b/src/server/webpack-config.js
@@ -8,14 +8,19 @@ const UIHARNESS_ENTRY = fsPath.join(__dirname, '../client/ui-harness');
 
 
 // Retrieve the path to the `react` module.
+//
 //  - First look within the UIHarness module, as that will be the
 //    latest version supported by UIHarness, and will be here if another reference
 //    has caused a different version of react to be held in the root node_modules.
+//
 //  - If not found locally, then grab react from the containing module.
+//
 const REACT_PATH = [
   fsPath.join(__dirname, '../../node_modules/react'),
   fsPath.join(NODE_MODULES_PATH, '/react'),
 ].find(fs.existsSync);
+
+
 
 
 

--- a/src/server/webpack-config.js
+++ b/src/server/webpack-config.js
@@ -1,5 +1,4 @@
 import webpack from 'webpack';
-import fs from 'fs-extra';
 import fsPath from 'path';
 import { rootModulePath, closestModulePath } from './paths';
 

--- a/src/server/webpack-config.js
+++ b/src/server/webpack-config.js
@@ -1,7 +1,7 @@
 import webpack from 'webpack';
 import fs from 'fs-extra';
 import fsPath from 'path';
-import { rootModulePath } from './paths';
+import { rootModulePath, closestModulePath } from './paths';
 
 const NODE_MODULES_PATH = fsPath.join(rootModulePath(), 'node_modules');
 const UIHARNESS_ENTRY = fsPath.join(__dirname, '../client/ui-harness');
@@ -13,14 +13,8 @@ const UIHARNESS_ENTRY = fsPath.join(__dirname, '../client/ui-harness');
 //    latest version supported by UIHarness, and will be here if another reference
 //    has caused a different version of react to be held in the root node_modules.
 //
-//  - If not found locally, then grab react from the containing module.
-//
-const REACT_PATH = [
-  fsPath.join(__dirname, '../../node_modules/react'),
-  fsPath.join(NODE_MODULES_PATH, '/react'),
-].find(fs.existsSync);
-
-
+//  - If not found locally, then walk up the tree to find the first reference of it.
+const REACT_PATH = closestModulePath(fsPath.join(__dirname, '../../'), 'react');
 
 
 
@@ -84,6 +78,10 @@ export default (options = {}) => {
   const isProduction = options.isProduction || false;
   const outputFile = options.outputFile || 'bundle.js';
   const isRelayEnabled = options.isRelayEnabled || false;
+
+  if (!REACT_PATH) {
+    throw new Error('The path to the `react` module was not found. Make sure it is installed');
+  }
 
   let vendor = options.vendor;
   if (vendor === undefined) {

--- a/test/server/paths.test.js
+++ b/test/server/paths.test.js
@@ -1,0 +1,52 @@
+import fs from 'fs-extra';
+import fsPath from 'path';
+import { expect } from 'chai';
+import * as paths from '../../src/server/paths';
+
+
+
+describe('server/paths', function() {
+
+  it('rootModulePath', () => {
+    expect(paths.rootModulePath()).to.equal(fsPath.resolve('./'));
+  });
+
+
+  describe('closestModulePath', function() {
+    const ROOT_DIR = fsPath.join(__dirname, '.paths.test')
+    const dir = (path) => fsPath.join(ROOT_DIR, path)
+
+    before(() => {
+      fs.ensureDirSync(dir('one/two/three/node_modules/react'));
+      fs.ensureDirSync(dir('one/node_modules/react'));
+      fs.ensureDirSync(dir('one/node_modules/string'));
+    });
+    after(() => {
+      fs.removeSync(ROOT_DIR);
+    });
+
+    it('retrieves `/one/two/three/node_modules/react`', () => {
+      const FOLDER = dir('one/two/three');
+      const result = paths.closestModulePath(FOLDER, 'react');
+      expect(result).to.equal(dir('one/two/three/node_modules/react'));
+    });
+
+    it('retrieves `/one/node_modules/react` (walk up 1-level)', () => {
+      const FOLDER = dir('one/two/');
+      const result = paths.closestModulePath(FOLDER, 'react');
+      expect(result).to.equal(dir('one/node_modules/react'));
+    });
+
+    it('retrieves `/one/node_modules/string` (walk up 2-levels)', () => {
+      const FOLDER = dir('one/two/three');
+      const result = paths.closestModulePath(FOLDER, 'string');
+      expect(result).to.equal(dir('one/node_modules/string'));
+    });
+
+    it('does not find a match', () => {
+      const FOLDER = dir('one/two/three');
+      const result = paths.closestModulePath(FOLDER, 'not-exist');
+      expect(result).to.equal(undefined);
+    });
+  });
+});


### PR DESCRIPTION
I situations where the react module is not within the `node_modules` directory this can cause hard to debug errors when running the `build` operation.

Namely, react is just not included in the `vendor` output.