### PR TITLE
Propose change from start -> uih in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Simply add it to you `package.json` file, with a `start` script:
   "name": "my-components",
   "version": "1.0.0",
   "scripts": {
-    "start": "node ./node_modules/ui-harness/start --entry=./src/specs",
+    "uih": "node ./node_modules/ui-harness/start --entry=./src/specs",
   },
   "devDependencies": {
     "ui-harness": "^3.3.0"
@@ -48,7 +48,7 @@ From here you can start developing your React components.  All the core dependen
 
 Now simply run:
 
-    npm start
+    npm run uih
 
 And navigate your browser to `http://localhost:3030`
 


### PR DESCRIPTION
I think that we shouldn't assume we should be the `start` script in package.json. People might think they need to have us as their `start` hook for the ui-harness to work, and thus won't use this. 

Keen to hear your thoughts, @philcockfield 