### PR TITLE
Don't try add keys to children. Fixes #85

### DIFF
--- a/src/components/Main/Component.jsx
+++ b/src/components/Main/Component.jsx
@@ -71,14 +71,6 @@ class Component extends React.Component {
 
       // Children.
       const children = current.get('componentChildren');
-      if (R.is(Array, children)) {
-        // Ensure all children in the array have keys.
-        children.forEach((child, i) => {
-          if (R.is(Object, child)) {
-            child.key = R.isNil(child.key) ? i : child.key;
-          }
-        });
-      }
       element = React.createElement(type, props, children);
 
       const childContextTypes = current.get('componentChildContextTypes');


### PR DESCRIPTION
This can be verified by inlining a list of components into a `.component` call. 

E.g.

``` js
describe('css-loader', function () {
  this.header(`## Webpack simple CSS loader.`);
  before(() => {
    this
      .component(
      <div className="css-loader-sample">
        <p>{ lorem(50) }</p>
        <p>{ lorem(50) }</p>
        <p>{ lorem(50) }</p>
      </div>
      );
  });
});
```
